### PR TITLE
Fixing the tinc version to match the rest and allow for installing ti…

### DIFF
--- a/packages/qmp-nycmesh/Makefile
+++ b/packages/qmp-nycmesh/Makefile
@@ -44,7 +44,7 @@ define Package/qmp-nycmesh
 	+luci-ssl \
 	+wget \
 	+reghack \
-	+tinc-1.1 \
+	+tinc \
 	+curl \
 	+6in4 \
 	+kmod-ipt-conntrack-extra \

--- a/packages/tinc-1.1/Makefile
+++ b/packages/tinc-1.1/Makefile
@@ -7,13 +7,15 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=tinc-1.1
-PKG_VERSION:=pre11
-PKG_RELEASE:=1
+PKG_NAME:=tinc
+PKG_VERSION:=1.1-pre11
+PKG_RELEASE:=$(PKG_SOURCE_VERSION)
 
-PKG_SOURCE:=tinc-1.1$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.tinc-vpn.org/packages
-#PKG_SOURCE_SUBDIR:=$(PKG_NAME)$(PKG_VERSION)
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=e44c337eae674120745f7c7c56a1a70919ff40ca
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_SOURCE_URL:=http://tinc-vpn.org/git/tinc
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_BUILD_DIR:= $(BUILD_DIR)/$(PKG_NAME)$(PKG_VERSION)
 
 PKG_FIXUP:=autoreconf
@@ -21,7 +23,7 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/tinc-1.1
+define Package/tinc
   SECTION:=utils
   CATEGORY:=qMp
   DEPENDS:=+liblzo +libopenssl +kmod-tun +libreadline +libncurses
@@ -31,7 +33,7 @@ define Package/tinc-1.1
   SUBMENU:=VPN
 endef
 
-define Package/tinc-1.1/description
+define Package/tinc/description
   tinc is a Virtual Private Network (VPN) daemon that uses tunnelling and
   encryption to create a secure private network between hosts on the Internet.
 endef
@@ -43,7 +45,7 @@ CONFIGURE_ARGS += \
 	--with-zlib="$(STAGING_DIR)/usr" \
 	--with-lzo-include="$(STAGING_DIR)/usr/include/lzo"
 
-define Package/tinc-1.1/install
+define Package/tinc/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tincd $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tinc $(1)/usr/sbin/
@@ -56,8 +58,8 @@ define Package/tinc-1.1/install
 	$(INSTALL_DATA) files/tinc.upgrade $(1)/lib/upgrade/keep.d/tinc
 endef
 
-define Package/tinc-1.1/conffiles
+define Package/tinc/conffiles
 /etc/config/tinc
 endef
 
-$(eval $(call BuildPackage,tinc-1.1))
+$(eval $(call BuildPackage,tinc))


### PR DESCRIPTION
…nc and make it simpler to upgrade to pre15 later

This fixes issues with the qMp 4.0 build. However I'm not 100% why.  It's probably a better way of handling the versioning anyways.